### PR TITLE
#patch: Single token, borrow layout, chain switch, search

### DIFF
--- a/src/components/ModalContent/ModalContent.tsx
+++ b/src/components/ModalContent/ModalContent.tsx
@@ -22,9 +22,17 @@ interface ModalContentProps {
 
 const ModalContent: React.FC<ModalContentProps> = ({ showModalByDefault }) => {
   const [widgetAction, setWidgetAction] = useState(WIDGET_ACTION_ENUM.BORROW);
+  const [key, setKey] = useState(0);
+
+  const handleWidgetAction = (action: WIDGET_ACTION_ENUM) => {
+    if (action === widgetAction && action === WIDGET_ACTION_ENUM.BORROW) {
+      setKey(prev => prev + 1);
+    }
+    setWidgetAction(action);
+  };
 
   const mapOptionToComponent = {
-    [WIDGET_ACTION_ENUM.BORROW]: <BorrowSection />,
+    [WIDGET_ACTION_ENUM.BORROW]: <BorrowSection key={key} />,
     [WIDGET_ACTION_ENUM.REPAY]: <RepaySection />,
   };
 
@@ -42,7 +50,7 @@ const ModalContent: React.FC<ModalContentProps> = ({ showModalByDefault }) => {
       <SelectButtons
         items={selectOptions}
         value={widgetAction}
-        onChange={setWidgetAction}
+        onChange={handleWidgetAction}
       />
       {mapOptionToComponent[widgetAction]}
     </>

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -42,7 +42,7 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
   selectedToken: token,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { setSelectedCollateralToken } = useGetBorrowSectionContext();
+  const { setSelectedCollateralToken, showOnlySingleTokenAddress } = useGetBorrowSectionContext();
 
   const onTokenDropdownRowClick = (token: UserToken) => {
     setSelectedCollateralToken(token);
@@ -64,12 +64,14 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
     <div className="token-dropdown" ref={ref}>
       <div
         className={cx("token-dropdown--row-container", isOpen && "opened")}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => !showOnlySingleTokenAddress && setIsOpen(!isOpen)}
       >
         <TokenDropdownRow token={token} />
-        <div className={cx("caret", isOpen && "opened")}>
-          <Icon icon="clarity:caret-line" />
-        </div>
+        {!showOnlySingleTokenAddress && (
+          <div className={cx("caret", isOpen && "opened")}>
+            <Icon icon="clarity:caret-line" />
+          </div>
+        )}
       </div>
       {isOpen && sortedTokens.length > 0 && (
         <div className="token-dropdown--tokens">

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -43,6 +43,7 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
   selectedToken: token,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const { setSelectedCollateralToken } = useGetBorrowSectionContext();
   const { singleWhitelistedToken } = useGetGlobalPropsContext();
 
@@ -51,14 +52,25 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
     setIsOpen(false);
   };
 
-  const ref = useOutsideClick(() => setIsOpen(false));
+  const ref = useOutsideClick(() => {
+    setIsOpen(false);
+    setSearchQuery("");
+  });
 
   const sortedTokens = [
     ...tokens
-      .filter((token) => parseFloat(token.balance) > 0)
+      .filter(
+        (token) =>
+          parseFloat(token.balance) > 0 &&
+          token.symbol.toLowerCase().includes(searchQuery.toLowerCase())
+      )
       .sort((a, b) => a.symbol.localeCompare(b.symbol)),
     ...tokens
-      .filter((token) => parseFloat(token.balance) <= 0)
+      .filter(
+        (token) =>
+          parseFloat(token.balance) <= 0 &&
+          token.symbol.toLowerCase().includes(searchQuery.toLowerCase())
+      )
       .sort((a, b) => a.symbol.localeCompare(b.symbol)),
   ];
 
@@ -75,8 +87,17 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
           </div>
         )}
       </div>
-      {isOpen && sortedTokens.length > 0 && (
-        <div className="token-dropdown--tokens">
+          {isOpen && (
+            <div className="token-dropdown--tokens">
+              <div className="search-container">
+                <input
+                  type="text"
+                  placeholder="Select collateral for deposit"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="token-dropdown--search"
+                />
+              </div>
           {sortedTokens.map((token) => (
             <TokenDropdownRow
               token={token}

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -44,7 +44,7 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { setSelectedCollateralToken } = useGetBorrowSectionContext();
-  const { showOnlySingleTokenAddress } = useGetGlobalPropsContext();
+  const { singleWhitelistedToken } = useGetGlobalPropsContext();
 
   const onTokenDropdownRowClick = (token: UserToken) => {
     setSelectedCollateralToken(token);
@@ -65,11 +65,11 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
   return (
     <div className="token-dropdown" ref={ref}>
       <div
-        className={cx("token-dropdown--row-container", isOpen && "opened", showOnlySingleTokenAddress && "disabled")}
-        onClick={() => !showOnlySingleTokenAddress && setIsOpen(!isOpen)}
+        className={cx("token-dropdown--row-container", isOpen && "opened", singleWhitelistedToken && "disabled")}
+        onClick={() => !singleWhitelistedToken && setIsOpen(!isOpen)}
       >
         <TokenDropdownRow token={token} />
-        {!showOnlySingleTokenAddress && (
+        {!singleWhitelistedToken && (
           <div className={cx("caret", isOpen && "opened")}>
             <Icon icon="clarity:caret-line" />
           </div>

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -69,9 +69,11 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
         onClick={() => !showOnlySingleTokenAddress && setIsOpen(!isOpen)}
       >
         <TokenDropdownRow token={token} />
-        <div className={cx("caret", isOpen && "opened")}>
-          <Icon icon="clarity:caret-line" />
-        </div>
+        {!showOnlySingleTokenAddress && (
+          <div className={cx("caret", isOpen && "opened")}>
+            <Icon icon="clarity:caret-line" />
+          </div>
+        )}
       </div>
       {isOpen && sortedTokens.length > 0 && (
         <div className="token-dropdown--tokens">

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -5,6 +5,7 @@ import TokenLogo from "../TokenLogo";
 import defaultTokenImage from "../../assets/generic_token-icon.svg";
 import "./tokenDropdown.scss";
 import { useGetBorrowSectionContext } from "../../pages/BorrowSection/BorrowSectionContext";
+import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 import useOutsideClick from "../../hooks/useOutsideClick";
 import { Icon } from "@iconify/react";
 

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -43,6 +43,7 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { setSelectedCollateralToken } = useGetBorrowSectionContext();
+  const { showOnlySingleTokenAddress } = useGetGlobalPropsContext();
 
   const onTokenDropdownRowClick = (token: UserToken) => {
     setSelectedCollateralToken(token);
@@ -64,7 +65,7 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
     <div className="token-dropdown" ref={ref}>
       <div
         className={cx("token-dropdown--row-container", isOpen && "opened")}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => !showOnlySingleTokenAddress && setIsOpen(!isOpen)}
       >
         <TokenDropdownRow token={token} />
         <div className={cx("caret", isOpen && "opened")}>

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -42,7 +42,7 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
   selectedToken: token,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { setSelectedCollateralToken, showOnlySingleTokenAddress } = useGetBorrowSectionContext();
+  const { setSelectedCollateralToken } = useGetBorrowSectionContext();
 
   const onTokenDropdownRowClick = (token: UserToken) => {
     setSelectedCollateralToken(token);
@@ -63,18 +63,13 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
   return (
     <div className="token-dropdown" ref={ref}>
       <div
-        className={cx("token-dropdown--row-container", isOpen && "opened", showOnlySingleTokenAddress && "disabled")}
-        onClick={() => {
-          if (showOnlySingleTokenAddress) return;
-          setIsOpen(!isOpen);
-        }}
+        className={cx("token-dropdown--row-container", isOpen && "opened")}
+        onClick={() => setIsOpen(!isOpen)}
       >
         <TokenDropdownRow token={token} />
-        {!showOnlySingleTokenAddress && (
-          <div className={cx("caret", isOpen && "opened")}>
-            <Icon icon="clarity:caret-line" />
-          </div>
-        )}
+        <div className={cx("caret", isOpen && "opened")}>
+          <Icon icon="clarity:caret-line" />
+        </div>
       </div>
       {isOpen && sortedTokens.length > 0 && (
         <div className="token-dropdown--tokens">

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -63,8 +63,11 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
   return (
     <div className="token-dropdown" ref={ref}>
       <div
-        className={cx("token-dropdown--row-container", isOpen && "opened")}
-        onClick={() => !showOnlySingleTokenAddress && setIsOpen(!isOpen)}
+        className={cx("token-dropdown--row-container", isOpen && "opened", showOnlySingleTokenAddress && "disabled")}
+        onClick={() => {
+          if (showOnlySingleTokenAddress) return;
+          setIsOpen(!isOpen);
+        }}
       >
         <TokenDropdownRow token={token} />
         {!showOnlySingleTokenAddress && (

--- a/src/components/TokenDropdown/TokenDropdown.tsx
+++ b/src/components/TokenDropdown/TokenDropdown.tsx
@@ -65,7 +65,7 @@ const TokenDropdown: React.FC<TokenDropdownProps> = ({
   return (
     <div className="token-dropdown" ref={ref}>
       <div
-        className={cx("token-dropdown--row-container", isOpen && "opened")}
+        className={cx("token-dropdown--row-container", isOpen && "opened", showOnlySingleTokenAddress && "disabled")}
         onClick={() => !showOnlySingleTokenAddress && setIsOpen(!isOpen)}
       >
         <TokenDropdownRow token={token} />

--- a/src/components/TokenDropdown/tokenDropdown.scss
+++ b/src/components/TokenDropdown/tokenDropdown.scss
@@ -14,11 +14,17 @@
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
     }
+    &.disabled {
+      cursor: default;
+    }
   }
   align-items: center;
   background-color: rgba(252, 252, 252, 1);
 
-  &:hover {
+  &.showOnlySingleTokenAddress:hover {
+    cursor: default;
+  }
+  &:not(.showOnlySingleTokenAddress):hover {
     cursor: pointer;
   }
 

--- a/src/components/TokenDropdown/tokenDropdown.scss
+++ b/src/components/TokenDropdown/tokenDropdown.scss
@@ -1,6 +1,10 @@
 @import "../../tokens.scss";
 
 .token-dropdown {
+  .disabled {
+    pointer-events: none;
+    opacity: 0.7;
+  }
   position: relative;
 
   &--row-container {

--- a/src/components/TokenDropdown/tokenDropdown.scss
+++ b/src/components/TokenDropdown/tokenDropdown.scss
@@ -1,13 +1,14 @@
 @import "../../tokens.scss";
 
 .token-dropdown {
-  .disabled {
-    pointer-events: none;
-    opacity: 0.7;
-  }
   position: relative;
 
   &--row-container {
+    &.disabled {
+      pointer-events: none;
+      opacity: 0.7;
+      cursor: not-allowed;
+    }
     display: flex;
     border-radius: $border-radius;
     position: relative;

--- a/src/components/TokenDropdown/tokenDropdown.scss
+++ b/src/components/TokenDropdown/tokenDropdown.scss
@@ -68,8 +68,35 @@
     z-index: 100;
     width: 100%;
     left: 0%;
-    max-height: 335px;
+    max-height: 375px;
     overflow-y: auto;
+
+    .search-container {
+      padding: 8px;
+      border: 0.5px solid $border-color-secondary;
+      border-top: 0;
+
+      .token-dropdown--search {
+        width: 100%;
+        padding: 8px 8px 8px 32px;
+        border: 0.5px solid $border-color-secondary;
+        border-radius: $border-radius;
+        font-size: 13px;
+        font-family: "Roboto";
+        outline: none;
+        background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='15' height='15' viewBox='0 0 24 24' fill='none' stroke='%2387a1a1' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='6'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'%3E%3C/line%3E%3C/svg%3E") 8px calc(50% - 0.5px) no-repeat;
+
+        color: #132725;
+
+        &:focus {
+          border-color: #bebebe;
+        }
+
+        &::placeholder {
+            color: #87a1a1;
+        }
+      }
+    }
 
     .token-dropdown--row {
       padding: $s-small $s-small $s-small $s-normal;

--- a/src/components/TokenDropdown/tokenDropdown.scss
+++ b/src/components/TokenDropdown/tokenDropdown.scss
@@ -4,11 +4,6 @@
   position: relative;
 
   &--row-container {
-    &.disabled {
-      pointer-events: none;
-      opacity: 0.7;
-      cursor: not-allowed;
-    }
     display: flex;
     border-radius: $border-radius;
     position: relative;

--- a/src/components/TokenDropdown/tokenDropdown.scss
+++ b/src/components/TokenDropdown/tokenDropdown.scss
@@ -21,10 +21,10 @@
   align-items: center;
   background-color: rgba(252, 252, 252, 1);
 
-  &.showOnlySingleTokenAddress:hover {
+  &.singleWhitelistedToken:hover {
     cursor: default;
   }
-  &:not(.showOnlySingleTokenAddress):hover {
+  &:not(.singleWhitelistedToken):hover {
     cursor: pointer;
   }
 

--- a/src/components/TokenInput/TokenInput.tsx
+++ b/src/components/TokenInput/TokenInput.tsx
@@ -47,7 +47,7 @@ const TokenInput: React.FC<TokenInputProps> = ({
   const [isMin, setIsMin] = useState(false);
 
   const maxValueBigInt = parseUnits(
-    (maxAmount ?? 0).toLocaleString('fullwide', { useGrouping: false }),
+    (maxAmount ?? 0).toLocaleString("fullwide", { useGrouping: false }),
     Number(tokenValue.token?.decimals) || 0
   );
 
@@ -101,7 +101,11 @@ const TokenInput: React.FC<TokenInputProps> = ({
     <div className="token-input-container">
       <div className="label-container">
         {label && <label className="section-title">{label}</label>}
-        {sublabelUpper && <label className="sublabel-upper section-sub-title">{sublabelUpper}</label>}
+        {sublabelUpper && (
+          <label className="sublabel-upper section-sub-title">
+            {sublabelUpper}
+          </label>
+        )}
       </div>
       <div className="token-input">
         <input

--- a/src/components/TokenInput/TokenInput.tsx
+++ b/src/components/TokenInput/TokenInput.tsx
@@ -1,109 +1,129 @@
-@import "../../tokens.scss";
+import { useAccount, useBalance, useReadContract } from "wagmi";
+import { UserToken } from "../../hooks/useGetUserTokens";
+import { AddressStringType } from "../../types/addressStringType";
+import { erc20Abi, formatUnits, parseUnits } from "viem";
+import { SubgraphTokenType } from "../../hooks/queries/useGetCommitmentsForCollateralToken";
 
-.token-input-container {
-  .token-input {
-    margin-top: $s-small;
-    padding: 10px 12px;
-    border: 0.5px solid $border-color-secondary;
-    border-radius: $border-radius;
-    background-color: $bg-light;
+import "./tokenInput.scss";
+import TokenLogo from "../TokenLogo";
+import defaultTokenImage from "../../assets/generic_token-icon.svg";
+import { useState } from "react";
 
-    display: flex;
+export type TokenInputType = {
+  value?: number;
+  token?: SubgraphTokenType;
+  valueBI?: bigint;
+};
 
-    input {
-      background: none;
-      border: none;
-      padding: 0;
-      cursor: text;
-      outline: inherit;
-
-      font-size: 13px;
-      font-family: "Roboto";
-
-      flex-grow: 1;
-
-      &[readonly] {
-        cursor: default;
-      }
-    }
-
-    input[type="number"] {
-      -moz-appearance: textfield;
-    }
-
-    input::-webkit-outer-spin-button,
-    input::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-
-    .max-button {
-      font-family: "Roboto";
-      font-size: 12px;
-      color: rgba(0, 70, 68, 1);
-      background-color: rgba(228, 249, 248, 1);
-      padding: 2px 9px;
-      border-radius: $border-radius;
-      margin-right: $s-small;
-
-      cursor: pointer;
-    }
-
-    .token-info {
-      border-left: 0.5px solid $border-color-secondary;
-      margin-top: -10px;
-      margin-bottom: -10px;
-      display: flex;
-      align-items: center;
-
-      padding-left: .3rem;
-
-      .token-logo {
-        margin-right: .22rem;
-      }
-
-      &-symbol {
-        font-family: "Roboto";
-        font-size: 11px;
-      }
-    }
-  }
-
-  .sublabel.section-sub-title {
-    margin-top: $s-small;
-    color: $text-secondary;
-    text-align: right;
-  }
-
-  .sublabel-upper.section-sub-title {
-    color: $text-secondary;
-    text-align: right;
-  }
-
-  .label-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .rollover-svg .outer {
-    fill: none;             
-    stroke: #3D8974;
-    stroke-width: 1.5;
-    overflow: visible;
-  }
-
-  .rollover-svg .check {
-    fill: #3D8974;          
-    stroke: #3D8974;        
-    stroke-width: 4;        
-    overflow: visible;
-  }
-
-
-  .tooltip-svg {
-    stroke: $text-secondary;
-    overflow: visible;
-  }
-
+interface TokenInputProps {
+  tokenValue: TokenInputType;
+  imageUrl: string | null;
+  label?: React.ReactNode;
+  sublabel?: string;
+  sublabelUpper?: React.ReactNode;
+  maxAmount?: number;
+  showMaxButton?: boolean;
+  onChange?: (value: TokenInputType) => void;
+  readonly?: boolean;
+  limitToMax?: boolean;
+  min?: boolean;
+  minAmount?: bigint;
 }
+
+const TokenInput: React.FC<TokenInputProps> = ({
+  tokenValue,
+  label,
+  maxAmount,
+  imageUrl,
+  sublabel,
+  sublabelUpper,
+  onChange,
+  readonly,
+  showMaxButton = true,
+  limitToMax = false,
+  min = false,
+  minAmount,
+}) => {
+  const [isMin, setIsMin] = useState(false);
+
+  const maxValueBigInt = parseUnits(
+    (maxAmount ?? 0).toLocaleString('fullwide', { useGrouping: false }),
+    Number(tokenValue.token?.decimals) || 0
+  );
+
+  const setMaxValue = () => {
+    if (isMin) {
+      onChange?.({
+        ...tokenValue,
+        value: Number(
+          formatUnits(minAmount ?? 0n, tokenValue.token?.decimals ?? 0)
+        ),
+        valueBI: minAmount,
+      });
+    } else {
+      onChange?.({
+        ...tokenValue,
+        value: maxAmount,
+        valueBI: maxValueBigInt,
+      });
+    }
+    min && setIsMin(!isMin);
+  };
+
+  const handleChange = (e: React.FormEvent<HTMLInputElement>) => {
+    if (!e.currentTarget.value) {
+      onChange?.({
+        ...tokenValue,
+        value: undefined,
+        valueBI: BigInt(0),
+      });
+      return;
+    }
+    if (limitToMax && maxAmount) {
+      if (Number(e.currentTarget.value) > maxAmount) {
+        setMaxValue();
+        return;
+      }
+    }
+    onChange?.({
+      ...tokenValue,
+      value: Number(e.currentTarget.value),
+      valueBI: parseUnits(
+        e.currentTarget.value,
+        tokenValue.token?.decimals ?? 0
+      ),
+    });
+  };
+
+  const logoUrl = imageUrl ? imageUrl : defaultTokenImage;
+
+  return (
+    <div className="token-input-container">
+      <div className="label-container">
+        {label && <label className="section-title">{label}</label>}
+        {sublabelUpper && <label className="sublabel-upper section-sub-title">{sublabelUpper}</label>}
+      </div>
+      <div className="token-input">
+        <input
+          type="number"
+          value={tokenValue?.value}
+          max={Number(tokenValue.value)}
+          onChange={handleChange}
+          readOnly={readonly}
+        />
+        {showMaxButton && !!maxAmount && (
+          <div className="max-button" onClick={setMaxValue}>
+            {isMin ? "MIN" : "MAX"}
+          </div>
+        )}
+        <div className="token-info">
+          <TokenLogo logoUrl={logoUrl} size={16} />
+          <span className="token-info-symbol">{tokenValue.token?.symbol}</span>
+        </div>
+      </div>
+      {sublabel && <div className="sublabel section-sub-title">{sublabel}</div>}
+    </div>
+  );
+};
+
+export default TokenInput;

--- a/src/components/TokenInput/TokenInput.tsx
+++ b/src/components/TokenInput/TokenInput.tsx
@@ -20,6 +20,7 @@ interface TokenInputProps {
   imageUrl: string | null;
   label?: React.ReactNode;
   sublabel?: string;
+  sublabelUpper?: React.ReactNode;
   maxAmount?: number;
   showMaxButton?: boolean;
   onChange?: (value: TokenInputType) => void;
@@ -35,6 +36,7 @@ const TokenInput: React.FC<TokenInputProps> = ({
   maxAmount,
   imageUrl,
   sublabel,
+  sublabelUpper,
   onChange,
   readonly,
   showMaxButton = true,
@@ -97,7 +99,10 @@ const TokenInput: React.FC<TokenInputProps> = ({
 
   return (
     <div className="token-input-container">
-      {label && <label className="section-title">{label}</label>}
+      <div className="label-container">
+        {label && <label className="section-title">{label}</label>}
+        {sublabelUpper && <label className="sublabel-upper section-sub-title">{sublabelUpper}</label>}
+      </div>
       <div className="token-input">
         <input
           type="number"

--- a/src/components/TokenInput/TokenInput.tsx
+++ b/src/components/TokenInput/TokenInput.tsx
@@ -45,8 +45,8 @@ const TokenInput: React.FC<TokenInputProps> = ({
   const [isMin, setIsMin] = useState(false);
 
   const maxValueBigInt = parseUnits(
-    (maxAmount ?? 0)?.toString(),
-    tokenValue.token?.decimals ?? 0
+    (maxAmount ?? 0).toLocaleString('fullwide', { useGrouping: false }),
+    Number(tokenValue.token?.decimals) || 0
   );
 
   const setMaxValue = () => {

--- a/src/components/TokenInput/TokenInput.tsx
+++ b/src/components/TokenInput/TokenInput.tsx
@@ -1,129 +1,109 @@
-import { useAccount, useBalance, useReadContract } from "wagmi";
-import { UserToken } from "../../hooks/useGetUserTokens";
-import { AddressStringType } from "../../types/addressStringType";
-import { erc20Abi, formatUnits, parseUnits } from "viem";
-import { SubgraphTokenType } from "../../hooks/queries/useGetCommitmentsForCollateralToken";
+@import "../../tokens.scss";
 
-import "./tokenInput.scss";
-import TokenLogo from "../TokenLogo";
-import defaultTokenImage from "../../assets/generic_token-icon.svg";
-import { useState } from "react";
+.token-input-container {
+  .token-input {
+    margin-top: $s-small;
+    padding: 10px 12px;
+    border: 0.5px solid $border-color-secondary;
+    border-radius: $border-radius;
+    background-color: $bg-light;
 
-export type TokenInputType = {
-  value?: number;
-  token?: SubgraphTokenType;
-  valueBI?: bigint;
-};
+    display: flex;
 
-interface TokenInputProps {
-  tokenValue: TokenInputType;
-  imageUrl: string | null;
-  label?: React.ReactNode;
-  sublabel?: string;
-  sublabelUpper?: React.ReactNode;
-  maxAmount?: number;
-  showMaxButton?: boolean;
-  onChange?: (value: TokenInputType) => void;
-  readonly?: boolean;
-  limitToMax?: boolean;
-  min?: boolean;
-  minAmount?: bigint;
-}
+    input {
+      background: none;
+      border: none;
+      padding: 0;
+      cursor: text;
+      outline: inherit;
 
-const TokenInput: React.FC<TokenInputProps> = ({
-  tokenValue,
-  label,
-  maxAmount,
-  imageUrl,
-  sublabel,
-  sublabelUpper,
-  onChange,
-  readonly,
-  showMaxButton = true,
-  limitToMax = false,
-  min = false,
-  minAmount,
-}) => {
-  const [isMin, setIsMin] = useState(false);
+      font-size: 13px;
+      font-family: "Roboto";
 
-  const maxValueBigInt = parseUnits(
-    (maxAmount ?? 0).toLocaleString('fullwide', { useGrouping: false }),
-    Number(tokenValue.token?.decimals) || 0
-  );
+      flex-grow: 1;
 
-  const setMaxValue = () => {
-    if (isMin) {
-      onChange?.({
-        ...tokenValue,
-        value: Number(
-          formatUnits(minAmount ?? 0n, tokenValue.token?.decimals ?? 0)
-        ),
-        valueBI: minAmount,
-      });
-    } else {
-      onChange?.({
-        ...tokenValue,
-        value: maxAmount,
-        valueBI: maxValueBigInt,
-      });
-    }
-    min && setIsMin(!isMin);
-  };
-
-  const handleChange = (e: React.FormEvent<HTMLInputElement>) => {
-    if (!e.currentTarget.value) {
-      onChange?.({
-        ...tokenValue,
-        value: undefined,
-        valueBI: BigInt(0),
-      });
-      return;
-    }
-    if (limitToMax && maxAmount) {
-      if (Number(e.currentTarget.value) > maxAmount) {
-        setMaxValue();
-        return;
+      &[readonly] {
+        cursor: default;
       }
     }
-    onChange?.({
-      ...tokenValue,
-      value: Number(e.currentTarget.value),
-      valueBI: parseUnits(
-        e.currentTarget.value,
-        tokenValue.token?.decimals ?? 0
-      ),
-    });
-  };
 
-  const logoUrl = imageUrl ? imageUrl : defaultTokenImage;
+    input[type="number"] {
+      -moz-appearance: textfield;
+    }
 
-  return (
-    <div className="token-input-container">
-      <div className="label-container">
-        {label && <label className="section-title">{label}</label>}
-        {sublabelUpper && <label className="sublabel-upper section-sub-title">{sublabelUpper}</label>}
-      </div>
-      <div className="token-input">
-        <input
-          type="number"
-          value={tokenValue?.value}
-          max={Number(tokenValue.value)}
-          onChange={handleChange}
-          readOnly={readonly}
-        />
-        {showMaxButton && !!maxAmount && (
-          <div className="max-button" onClick={setMaxValue}>
-            {isMin ? "MIN" : "MAX"}
-          </div>
-        )}
-        <div className="token-info">
-          <TokenLogo logoUrl={logoUrl} size={16} />
-          <span className="token-info-symbol">{tokenValue.token?.symbol}</span>
-        </div>
-      </div>
-      {sublabel && <div className="sublabel section-sub-title">{sublabel}</div>}
-    </div>
-  );
-};
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
 
-export default TokenInput;
+    .max-button {
+      font-family: "Roboto";
+      font-size: 12px;
+      color: rgba(0, 70, 68, 1);
+      background-color: rgba(228, 249, 248, 1);
+      padding: 2px 9px;
+      border-radius: $border-radius;
+      margin-right: $s-small;
+
+      cursor: pointer;
+    }
+
+    .token-info {
+      border-left: 0.5px solid $border-color-secondary;
+      margin-top: -10px;
+      margin-bottom: -10px;
+      display: flex;
+      align-items: center;
+
+      padding-left: .3rem;
+
+      .token-logo {
+        margin-right: .22rem;
+      }
+
+      &-symbol {
+        font-family: "Roboto";
+        font-size: 11px;
+      }
+    }
+  }
+
+  .sublabel.section-sub-title {
+    margin-top: $s-small;
+    color: $text-secondary;
+    text-align: right;
+  }
+
+  .sublabel-upper.section-sub-title {
+    color: $text-secondary;
+    text-align: right;
+  }
+
+  .label-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .rollover-svg .outer {
+    fill: none;             
+    stroke: #3D8974;
+    stroke-width: 1.5;
+    overflow: visible;
+  }
+
+  .rollover-svg .check {
+    fill: #3D8974;          
+    stroke: #3D8974;        
+    stroke-width: 4;        
+    overflow: visible;
+  }
+
+
+  .tooltip-svg {
+    stroke: $text-secondary;
+    overflow: visible;
+  }
+
+}

--- a/src/components/TokenInput/tokenInput.scss
+++ b/src/components/TokenInput/tokenInput.scss
@@ -82,8 +82,8 @@
 
   .label-container {
     display: flex;
-    justify-content: space-between; /* This spaces out the items */
-    align-items: center; /* This vertically centers the items (optional) */
+    justify-content: space-between;
+    align-items: center;
   }
 
   .rollover-svg {

--- a/src/components/TokenInput/tokenInput.scss
+++ b/src/components/TokenInput/tokenInput.scss
@@ -74,4 +74,20 @@
     color: $text-secondary;
     text-align: right;
   }
+
+  .sublabel-upper.section-sub-title {
+    color: $text-secondary;
+    text-align: right;
+  }
+
+  .label-container {
+    display: flex;
+    justify-content: space-between; /* This spaces out the items */
+    align-items: center; /* This vertically centers the items (optional) */
+  }
+
+  .rollover-svg {
+    stroke: $text-secondary;
+  }
+
 }

--- a/src/components/TokenInput/tokenInput.scss
+++ b/src/components/TokenInput/tokenInput.scss
@@ -86,8 +86,24 @@
     align-items: center;
   }
 
-  .rollover-svg {
+  .rollover-svg .outer {
+    fill: none;             
+    stroke: #3D8974;
+    stroke-width: 1.5;
+    overflow: visible;
+  }
+
+  .rollover-svg .check {
+    fill: #3D8974;          
+    stroke: #3D8974;        
+    stroke-width: 4;        
+    overflow: visible;
+  }
+
+
+  .tooltip-svg {
     stroke: $text-secondary;
+    overflow: visible;
   }
 
 }

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -35,7 +35,6 @@ interface BaseWidgetProps {
   subgraphApiKey: string;
   isEmbedded?: boolean;
   showChainSwitch?: boolean;
-  showOnlySingleTokenAddress?: string;
 }
 
 interface WhiteListedTokensRequiredProps extends BaseWidgetProps {

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -35,6 +35,7 @@ interface BaseWidgetProps {
   subgraphApiKey: string;
   isEmbedded?: boolean;
   showChainSwitch?: boolean;
+  showOnlySingleTokenAddress?: string;
 }
 
 interface WhiteListedTokensRequiredProps extends BaseWidgetProps {

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -70,6 +70,7 @@ const Widget: React.FC<WidgetProps> = ({
   subgraphApiKey,
   isEmbedded = false,
   showChainSwitch = true,
+  showOnlySingleTokenAddress,
 }) => {
   const [showModal, setShowModal] = useState(showModalByDefault || false);
 

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -95,6 +95,7 @@ const Widget: React.FC<WidgetProps> = ({
           buttonColorPrimary={buttonColorPrimary}
           buttonTextColorPrimary={buttonTextColorPrimary}
           subgraphApiKey={subgraphApiKey}
+          showOnlySingleTokenAddress={showOnlySingleTokenAddress}
         >
           <div className="teller-widget">
             <Modal

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -35,7 +35,7 @@ interface BaseWidgetProps {
   subgraphApiKey: string;
   isEmbedded?: boolean;
   showChainSwitch?: boolean;
-  showOnlySingleTokenAddress?: string;
+  singleWhitelistedToken?: string;
 }
 
 interface WhiteListedTokensRequiredProps extends BaseWidgetProps {
@@ -70,7 +70,7 @@ const Widget: React.FC<WidgetProps> = ({
   subgraphApiKey,
   isEmbedded = false,
   showChainSwitch = true,
-  showOnlySingleTokenAddress,
+  singleWhitelistedToken,
 }) => {
   const [showModal, setShowModal] = useState(showModalByDefault || false);
 
@@ -96,7 +96,7 @@ const Widget: React.FC<WidgetProps> = ({
           buttonColorPrimary={buttonColorPrimary}
           buttonTextColorPrimary={buttonTextColorPrimary}
           subgraphApiKey={subgraphApiKey}
-          showOnlySingleTokenAddress={showOnlySingleTokenAddress}
+          singleWhitelistedToken={singleWhitelistedToken}
         >
           <div className="teller-widget">
             <Modal

--- a/src/components/Widget/widget.stories.tsx
+++ b/src/components/Widget/widget.stories.tsx
@@ -8,7 +8,7 @@ import { config } from "../../helpers/createWagmiConfig";
 import "./widgetStories.scss";
 import Widget from ".";
 
-const SUBGRAPH_API_KEY = "2f26b4c1f77ea8ff641c8dd081795939";
+const SUBGRAPH_API_KEY = "945bcc23bc7f0a6f3956725a9c3513a1";
 
 const meta = {
   title: "Widget",

--- a/src/components/Widget/widget.stories.tsx
+++ b/src/components/Widget/widget.stories.tsx
@@ -8,7 +8,7 @@ import { config } from "../../helpers/createWagmiConfig";
 import "./widgetStories.scss";
 import Widget from ".";
 
-const SUBGRAPH_API_KEY = "945bcc23bc7f0a6f3956725a9c3513a1";
+const SUBGRAPH_API_KEY = "2f26b4c1f77ea8ff641c8dd081795939";
 
 const meta = {
   title: "Widget",

--- a/src/contexts/GlobalPropsContext.tsx
+++ b/src/contexts/GlobalPropsContext.tsx
@@ -15,7 +15,6 @@ export type GlobalPropsContextType = {
   buttonColorPrimary?: string;
   buttonTextColorPrimary?: string;
   subgraphApiKey: string;
-  showOnlySingleTokenAddress?: string;
 };
 
 interface GlobalPropsContextProps {
@@ -28,7 +27,6 @@ interface GlobalPropsContextProps {
   buttonColorPrimary?: string;
   buttonTextColorPrimary?: string;
   subgraphApiKey: string;
-  showOnlySingleTokenAddress?: string;
 }
 
 const GlobalPropsContext = createContext({} as GlobalPropsContextType);
@@ -43,7 +41,6 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
   buttonColorPrimary = undefined,
   buttonTextColorPrimary = undefined,
   subgraphApiKey,
-  showOnlySingleTokenAddress,
 }) => {
   const [_userTokens, setUserTokens] = useState<any[]>([]);
   const chainId = useChainId();
@@ -83,7 +80,6 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
         buttonColorPrimary,
         buttonTextColorPrimary,
         subgraphApiKey,
-        showOnlySingleTokenAddress,
       }}
     >
       {children}

--- a/src/contexts/GlobalPropsContext.tsx
+++ b/src/contexts/GlobalPropsContext.tsx
@@ -15,7 +15,7 @@ export type GlobalPropsContextType = {
   buttonColorPrimary?: string;
   buttonTextColorPrimary?: string;
   subgraphApiKey: string;
-  showOnlySingleTokenAddress?: string;
+  singleWhitelistedToken?: string;
 };
 
 interface GlobalPropsContextProps {
@@ -28,7 +28,7 @@ interface GlobalPropsContextProps {
   buttonColorPrimary?: string;
   buttonTextColorPrimary?: string;
   subgraphApiKey: string;
-  showOnlySingleTokenAddress?: string;
+  singleWhitelistedToken?: string;
 }
 
 const GlobalPropsContext = createContext({} as GlobalPropsContextType);
@@ -43,7 +43,7 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
   buttonColorPrimary = undefined,
   buttonTextColorPrimary = undefined,
   subgraphApiKey,
-  showOnlySingleTokenAddress,
+  singleWhitelistedToken,
 }) => {
   const [_userTokens, setUserTokens] = useState<any[]>([]);
   const chainId = useChainId();
@@ -89,7 +89,7 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
         buttonColorPrimary,
         buttonTextColorPrimary,
         subgraphApiKey,
-        showOnlySingleTokenAddress,
+        singleWhitelistedToken,
       }}
     >
       {children}

--- a/src/contexts/GlobalPropsContext.tsx
+++ b/src/contexts/GlobalPropsContext.tsx
@@ -59,8 +59,14 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
   );
 
   useEffect(() => {
+    let mounted = true;
     if (_userTokens?.length > 0) return;
-    setUserTokens(userTokens);
+    if (mounted) {
+      setUserTokens(userTokens);
+    }
+    return () => {
+      mounted = false;
+    };
   }, [_userTokens?.length, userTokens]);
 
   useEffect(() => {

--- a/src/contexts/GlobalPropsContext.tsx
+++ b/src/contexts/GlobalPropsContext.tsx
@@ -15,6 +15,7 @@ export type GlobalPropsContextType = {
   buttonColorPrimary?: string;
   buttonTextColorPrimary?: string;
   subgraphApiKey: string;
+  showOnlySingleTokenAddress?: string;
 };
 
 interface GlobalPropsContextProps {
@@ -27,6 +28,7 @@ interface GlobalPropsContextProps {
   buttonColorPrimary?: string;
   buttonTextColorPrimary?: string;
   subgraphApiKey: string;
+  showOnlySingleTokenAddress?: string;
 }
 
 const GlobalPropsContext = createContext({} as GlobalPropsContextType);
@@ -41,6 +43,7 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
   buttonColorPrimary = undefined,
   buttonTextColorPrimary = undefined,
   subgraphApiKey,
+  showOnlySingleTokenAddress,
 }) => {
   const [_userTokens, setUserTokens] = useState<any[]>([]);
   const chainId = useChainId();
@@ -80,6 +83,7 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
         buttonColorPrimary,
         buttonTextColorPrimary,
         subgraphApiKey,
+        showOnlySingleTokenAddress,
       }}
     >
       {children}

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useEffect } from "react";
 import { useChainId } from "wagmi";
+import { parseUnits } from "viem";
 import { useGetTokenMetadata } from "../../hooks/useGetTokenMetadata";
 import BorrowerTerms from "./BorrowerTerms";
 import {
@@ -36,7 +37,7 @@ const formatAddressForAlchemy = (address: string): string | undefined => {
 };
 
 const RenderComponent: React.FC = () => {
-  const { whitelistedChainTokens, singleWhitelistedToken } = useGetGlobalPropsContext();
+  const { whitelistedChainTokens, singleWhitelistedToken, userTokens } = useGetGlobalPropsContext();
   const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
   const chainId = useChainId();
 
@@ -45,12 +46,20 @@ const RenderComponent: React.FC = () => {
 
   useEffect(() => {
     if (tokenAddress && tokenMetadata && !isLoading) {
+      const tokenBalance = userTokens.find(token => 
+        token.address.toLowerCase() === tokenAddress.toLowerCase()
+      )?.balance || '0';
+      
+      const balanceUnits = parseUnits(tokenBalance, tokenMetadata.decimals || 18);
+      const balanceBigInt = BigInt(balanceUnits.toString());
+
       setSelectedCollateralToken({
         address: tokenAddress as `0x${string}`,
         name: tokenMetadata.name || '',
         symbol: tokenMetadata.symbol || '',
         logo: tokenMetadata.logo || '',
-        balance: '0',
+        balance: tokenBalance,
+        balanceBigInt: balanceBigInt,
         decimals: tokenMetadata.decimals || 18,
         chainId
       });

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -22,11 +22,8 @@ const RenderComponent: React.FC = () => {
   useEffect(() => {
     console.log("showOnlySingleTokenAddress", showOnlySingleTokenAddress)
     if (showOnlySingleTokenAddress?.startsWith('0x')) {
-      const token = whitelistedChainTokens?.find(t => t.address.toLowerCase() === showOnlySingleTokenAddress.toLowerCase());
-      if (token) {
-        setSelectedCollateralToken(token);
-        setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
-      }
+      setSelectedCollateralToken({ address: `0x${showOnlySingleTokenAddress}` });
+      setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
     }
   }, [showOnlySingleTokenAddress, whitelistedChainTokens, setSelectedCollateralToken, setCurrentStep]);
   const mapStepToComponent = useMemo(

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -15,9 +15,19 @@ import AddToCalendar from "../../components/AddToCalendar";
 import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 
 const RenderComponent: React.FC = () => {
-  const { whitelistedChainTokens } = useGetGlobalPropsContext();
-  const { currentStep, setCurrentStep, bidId } = useGetBorrowSectionContext();
+  const { whitelistedChainTokens, showOnlySingleTokenAddress } = useGetGlobalPropsContext();
+  const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
   const chainId = useChainId();
+
+  useEffect(() => {
+    if (showOnlySingleTokenAddress?.startsWith('0x')) {
+      const token = whitelistedChainTokens?.find(t => t.address.toLowerCase() === showOnlySingleTokenAddress.toLowerCase());
+      if (token) {
+        setSelectedCollateralToken(token);
+        setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
+      }
+    }
+  }, [showOnlySingleTokenAddress, whitelistedChainTokens, setSelectedCollateralToken, setCurrentStep]);
   const mapStepToComponent = useMemo(
     () => ({
       [BorrowSectionSteps.SELECT_TOKEN]: <CollateralTokenList />,

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -44,7 +44,15 @@ const RenderComponent: React.FC = () => {
   );
 };
 
-const BorrowSection: React.FC = () => {
+const BorrowSection: React.FC<{ isActive?: boolean }> = ({ isActive }) => {
+  const { setCurrentStep } = useGetBorrowSectionContext();
+
+  useEffect(() => {
+    if (isActive) {
+      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
+    }
+  }, [isActive, setCurrentStep]);
+
   return (
     <BorrowSectionContextProvider>
       <RenderComponent />

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -16,56 +16,48 @@ import BorrowConfirmation from "./BorrowConfirmation";
 import AddToCalendar from "../../components/AddToCalendar";
 import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 
-const formatAddressForAlchemy = (address: string): string | undefined => {
-  if (!address) return undefined;
-
-  // Remove accidental spaces, quotes, or invalid characters
-  let formattedAddress = address.trim().toLowerCase();
-
-  // Ensure it starts with "0x"
-  if (!formattedAddress.startsWith("0x")) {
-    formattedAddress = `0x${formattedAddress}`;
-  }
-
-  // Validate that it's exactly 42 characters long
-  if (/^0x[a-fA-F0-9]{40}$/.test(formattedAddress)) {
-    return formattedAddress;
-  }
-
-  console.error("Invalid Ethereum address:", address);
-  return undefined;
-};
-
 const RenderComponent: React.FC = () => {
-  const { whitelistedChainTokens, singleWhitelistedToken, userTokens } = useGetGlobalPropsContext();
-  const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
+  const { whitelistedChainTokens, singleWhitelistedToken, userTokens } =
+    useGetGlobalPropsContext();
+  const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } =
+    useGetBorrowSectionContext();
   const chainId = useChainId();
 
-  const tokenAddress = formatAddressForAlchemy(singleWhitelistedToken || "");
-  const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || '');
+  const tokenAddress = singleWhitelistedToken?.toLowerCase() || "";
+  const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || "");
 
   useEffect(() => {
     if (tokenAddress && tokenMetadata && !isLoading) {
-      const tokenBalance = userTokens.find(token => 
-        token.address.toLowerCase() === tokenAddress.toLowerCase()
-      )?.balance || '0';
-      
-      const balanceUnits = parseUnits(tokenBalance, tokenMetadata.decimals || 18);
+      const tokenBalance =
+        userTokens.find(
+          (token) => token.address.toLowerCase() === tokenAddress.toLowerCase()
+        )?.balance || "0";
+
+      const balanceUnits = parseUnits(
+        tokenBalance,
+        tokenMetadata.decimals || 18
+      );
       const balanceBigInt = BigInt(balanceUnits.toString());
 
       setSelectedCollateralToken({
         address: tokenAddress as `0x${string}`,
-        name: tokenMetadata.name || '',
-        symbol: tokenMetadata.symbol || '',
-        logo: tokenMetadata.logo || '',
+        name: tokenMetadata.name || "",
+        symbol: tokenMetadata.symbol || "",
+        logo: tokenMetadata.logo || "",
         balance: tokenBalance,
         balanceBigInt: balanceBigInt,
         decimals: tokenMetadata.decimals || 18,
-        chainId
       });
       setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
     }
-  }, [tokenAddress, tokenMetadata, isLoading, chainId, setSelectedCollateralToken, setCurrentStep]);
+  }, [
+    tokenAddress,
+    tokenMetadata,
+    isLoading,
+    setSelectedCollateralToken,
+    setCurrentStep,
+  ]);
+
   const mapStepToComponent = useMemo(
     () => ({
       [BorrowSectionSteps.SELECT_TOKEN]: <CollateralTokenList />,

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -45,19 +45,17 @@ const RenderComponent: React.FC = () => {
 };
 
 const BorrowSection: React.FC<{ isActive?: boolean }> = ({ isActive }) => {
-  const [shouldReset, setShouldReset] = useState(false);
+  const { setCurrentStep } = useGetBorrowSectionContext();
 
   useEffect(() => {
-    if (isActive && shouldReset) {
-      setShouldReset(false);
-    } else if (isActive) {
-      setShouldReset(true);
+    if (isActive) {
+      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
     }
-  }, [isActive]);
+  }, [isActive, setCurrentStep]);
 
   return (
     <BorrowSectionContextProvider>
-      <RenderComponent key={shouldReset ? "reset" : "default"} />
+      <RenderComponent />
     </BorrowSectionContextProvider>
   );
 };

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -44,7 +44,6 @@ const RenderComponent: React.FC = () => {
   const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || '');
 
   useEffect(() => {
-    console.log("showOnlySingleTokenAddress", showOnlySingleTokenAddress);
     if (tokenAddress && tokenMetadata && !isLoading) {
       setSelectedCollateralToken({
         address: tokenAddress as `0x${string}`,

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -36,11 +36,11 @@ const formatAddressForAlchemy = (address: string): string | undefined => {
 };
 
 const RenderComponent: React.FC = () => {
-  const { whitelistedChainTokens, showOnlySingleTokenAddress } = useGetGlobalPropsContext();
+  const { whitelistedChainTokens, singleWhitelistedToken } = useGetGlobalPropsContext();
   const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
   const chainId = useChainId();
 
-  const tokenAddress = formatAddressForAlchemy(showOnlySingleTokenAddress || "");
+  const tokenAddress = formatAddressForAlchemy(singleWhitelistedToken || "");
   const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || '');
 
   useEffect(() => {

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -76,10 +76,8 @@ const RenderComponent: React.FC = () => {
   );
 
   useEffect(() => {
-    if (!showOnlySingleTokenAddress && currentStep === BorrowSectionSteps.SELECT_OPPORTUNITY) {
-      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
-    }
-  }, [chainId, setCurrentStep, whitelistedChainTokens, showOnlySingleTokenAddress, currentStep]);
+    setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
+  }, [chainId, setCurrentStep, whitelistedChainTokens]);
 
   return (
     <div className="borrow-section">{mapStepToComponent[currentStep]}</div>

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -76,10 +76,8 @@ const RenderComponent: React.FC = () => {
   );
 
   useEffect(() => {
-    if (!showOnlySingleTokenAddress) {
-      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
-    }
-  }, [chainId, setCurrentStep, whitelistedChainTokens, showOnlySingleTokenAddress]);
+    setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
+  }, [chainId, setCurrentStep, whitelistedChainTokens]);
 
   return (
     <div className="borrow-section">{mapStepToComponent[currentStep]}</div>

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -15,19 +15,9 @@ import AddToCalendar from "../../components/AddToCalendar";
 import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 
 const RenderComponent: React.FC = () => {
-  const { whitelistedChainTokens, showOnlySingleTokenAddress } = useGetGlobalPropsContext();
-  const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
+  const { whitelistedChainTokens } = useGetGlobalPropsContext();
+  const { currentStep, setCurrentStep, bidId } = useGetBorrowSectionContext();
   const chainId = useChainId();
-
-  useEffect(() => {
-    if (showOnlySingleTokenAddress?.startsWith('0x')) {
-      const token = whitelistedChainTokens?.find(t => t.address.toLowerCase() === showOnlySingleTokenAddress.toLowerCase());
-      if (token) {
-        setSelectedCollateralToken(token);
-        setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
-      }
-    }
-  }, [showOnlySingleTokenAddress, whitelistedChainTokens, setSelectedCollateralToken, setCurrentStep]);
   const mapStepToComponent = useMemo(
     () => ({
       [BorrowSectionSteps.SELECT_TOKEN]: <CollateralTokenList />,

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useEffect } from "react";
 import { useChainId } from "wagmi";
+import { useGetTokenMetadata } from "../../hooks/useGetTokenMetadata";
 import BorrowerTerms from "./BorrowerTerms";
 import {
   BorrowSectionContextProvider,
@@ -27,7 +28,7 @@ const RenderComponent: React.FC = () => {
       
       if (tokenMetadata && !isLoading) {
         setSelectedCollateralToken({
-          address: tokenAddress,
+          address: `0x${tokenAddress}`,
           name: tokenMetadata.name || '',
           symbol: tokenMetadata.symbol || '',
           logo: tokenMetadata.logo || '',

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -22,8 +22,21 @@ const RenderComponent: React.FC = () => {
   useEffect(() => {
     console.log("showOnlySingleTokenAddress", showOnlySingleTokenAddress)
     if (showOnlySingleTokenAddress?.startsWith('0x')) {
-      setSelectedCollateralToken({ address: `0x${showOnlySingleTokenAddress}` });
-      setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
+      const tokenAddress = `0x${showOnlySingleTokenAddress}`;
+      const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress);
+      
+      if (tokenMetadata && !isLoading) {
+        setSelectedCollateralToken({
+          address: tokenAddress,
+          name: tokenMetadata.name || '',
+          symbol: tokenMetadata.symbol || '',
+          logo: tokenMetadata.logo || '',
+          balance: '0',
+          decimals: tokenMetadata.decimals || 18,
+          chainId
+        });
+        setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
+      }
     }
   }, [showOnlySingleTokenAddress, whitelistedChainTokens, setSelectedCollateralToken, setCurrentStep]);
   const mapStepToComponent = useMemo(

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -76,8 +76,10 @@ const RenderComponent: React.FC = () => {
   );
 
   useEffect(() => {
-    setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
-  }, [chainId, setCurrentStep, whitelistedChainTokens]);
+    if (!showOnlySingleTokenAddress && currentStep === BorrowSectionSteps.SELECT_OPPORTUNITY) {
+      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
+    }
+  }, [chainId, setCurrentStep, whitelistedChainTokens, showOnlySingleTokenAddress, currentStep]);
 
   return (
     <div className="borrow-section">{mapStepToComponent[currentStep]}</div>

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -45,17 +45,19 @@ const RenderComponent: React.FC = () => {
 };
 
 const BorrowSection: React.FC<{ isActive?: boolean }> = ({ isActive }) => {
-  const { setCurrentStep } = useGetBorrowSectionContext();
+  const [shouldReset, setShouldReset] = useState(false);
 
   useEffect(() => {
-    if (isActive) {
-      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
+    if (isActive && shouldReset) {
+      setShouldReset(false);
+    } else if (isActive) {
+      setShouldReset(true);
     }
-  }, [isActive, setCurrentStep]);
+  }, [isActive]);
 
   return (
     <BorrowSectionContextProvider>
-      <RenderComponent />
+      <RenderComponent key={shouldReset ? "reset" : "default"} />
     </BorrowSectionContextProvider>
   );
 };

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -15,32 +15,12 @@ import BorrowConfirmation from "./BorrowConfirmation";
 import AddToCalendar from "../../components/AddToCalendar";
 import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 
-const formatAddressForAlchemy = (address: string): string | undefined => {
-  if (!address) return undefined;
-
-  // Remove accidental spaces, quotes, or invalid characters
-  let formattedAddress = address.trim().toLowerCase();
-
-  // Ensure it starts with "0x"
-  if (!formattedAddress.startsWith("0x")) {
-    formattedAddress = `0x${formattedAddress}`;
-  }
-
-  // Validate that it's exactly 42 characters long
-  if (/^0x[a-fA-F0-9]{40}$/.test(formattedAddress)) {
-    return formattedAddress;
-  }
-
-  console.error("Invalid Ethereum address:", address);
-  return undefined;
-};
-
 const RenderComponent: React.FC = () => {
   const { whitelistedChainTokens, showOnlySingleTokenAddress } = useGetGlobalPropsContext();
   const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
   const chainId = useChainId();
 
-  const tokenAddress = formatAddressForAlchemy(showOnlySingleTokenAddress || "");
+  const tokenAddress = showOnlySingleTokenAddress?.startsWith('0x') ? `0x${showOnlySingleTokenAddress}` : undefined;
   const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || '');
 
   useEffect(() => {

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -44,15 +44,7 @@ const RenderComponent: React.FC = () => {
   );
 };
 
-const BorrowSection: React.FC<{ isActive?: boolean }> = ({ isActive }) => {
-  const { setCurrentStep } = useGetBorrowSectionContext();
-
-  useEffect(() => {
-    if (isActive) {
-      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
-    }
-  }, [isActive, setCurrentStep]);
-
+const BorrowSection: React.FC = () => {
   return (
     <BorrowSectionContextProvider>
       <RenderComponent />

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -15,12 +15,32 @@ import BorrowConfirmation from "./BorrowConfirmation";
 import AddToCalendar from "../../components/AddToCalendar";
 import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 
+const formatAddressForAlchemy = (address: string): string | undefined => {
+  if (!address) return undefined;
+
+  // Remove accidental spaces, quotes, or invalid characters
+  let formattedAddress = address.trim().toLowerCase();
+
+  // Ensure it starts with "0x"
+  if (!formattedAddress.startsWith("0x")) {
+    formattedAddress = `0x${formattedAddress}`;
+  }
+
+  // Validate that it's exactly 42 characters long
+  if (/^0x[a-fA-F0-9]{40}$/.test(formattedAddress)) {
+    return formattedAddress;
+  }
+
+  console.error("Invalid Ethereum address:", address);
+  return undefined;
+};
+
 const RenderComponent: React.FC = () => {
   const { whitelistedChainTokens, showOnlySingleTokenAddress } = useGetGlobalPropsContext();
   const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
   const chainId = useChainId();
 
-  const tokenAddress = showOnlySingleTokenAddress?.startsWith('0x') ? `0x${showOnlySingleTokenAddress}` : undefined;
+  const tokenAddress = formatAddressForAlchemy(showOnlySingleTokenAddress || "");
   const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || '');
 
   useEffect(() => {

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -20,6 +20,7 @@ const RenderComponent: React.FC = () => {
   const chainId = useChainId();
 
   useEffect(() => {
+    console.log("showOnlySingleTokenAddress", showOnlySingleTokenAddress)
     if (showOnlySingleTokenAddress?.startsWith('0x')) {
       const token = whitelistedChainTokens?.find(t => t.address.toLowerCase() === showOnlySingleTokenAddress.toLowerCase());
       if (token) {

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -76,8 +76,10 @@ const RenderComponent: React.FC = () => {
   );
 
   useEffect(() => {
-    setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
-  }, [chainId, setCurrentStep, whitelistedChainTokens]);
+    if (!showOnlySingleTokenAddress) {
+      setCurrentStep(BorrowSectionSteps.SELECT_TOKEN);
+    }
+  }, [chainId, setCurrentStep, whitelistedChainTokens, showOnlySingleTokenAddress]);
 
   return (
     <div className="borrow-section">{mapStepToComponent[currentStep]}</div>

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useEffect } from "react";
 import { useChainId } from "wagmi";
-import { useAlchemy } from '@alch/alchemy-web3'; // Added Alchemy import - ASSUMPTION
 import BorrowerTerms from "./BorrowerTerms";
 import {
   BorrowSectionContextProvider,
@@ -15,49 +14,18 @@ import BorrowConfirmation from "./BorrowConfirmation";
 import AddToCalendar from "../../components/AddToCalendar";
 import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 
-// Added UserToken type definition - ASSUMPTION
-type UserToken = {
-  address: `0x${string}`;
-  name: string;
-  symbol: string;
-  logo: string;
-  balance: string;
-  balanceBigInt: bigint;
-  decimals: number;
-};
-
-
 const RenderComponent: React.FC = () => {
   const { whitelistedChainTokens, showOnlySingleTokenAddress } = useGetGlobalPropsContext();
   const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
   const chainId = useChainId();
-  const alchemy = useAlchemy(); // Added Alchemy hook call
-
 
   useEffect(() => {
+    console.log("showOnlySingleTokenAddress", showOnlySingleTokenAddress)
     if (showOnlySingleTokenAddress?.startsWith('0x')) {
-      const fetchTokenData = async () => {
-        try {
-          const metadata = await alchemy.core.getTokenMetadata(showOnlySingleTokenAddress);
-          const token: UserToken = {
-            address: showOnlySingleTokenAddress,
-            name: metadata.name ?? '',
-            symbol: metadata.symbol ?? '',
-            logo: metadata.logo ?? '',
-            balance: '0',
-            balanceBigInt: BigInt(0),
-            decimals: metadata.decimals ?? 18,
-          };
-          setSelectedCollateralToken(token);
-          setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
-        } catch (error) {
-          console.error("Error fetching token metadata:", error);
-          // Handle error appropriately, e.g., display an error message
-        }
-      };
-      void fetchTokenData();
+      setSelectedCollateralToken({ address: `0x${showOnlySingleTokenAddress}` });
+      setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
     }
-  }, [showOnlySingleTokenAddress, alchemy, setSelectedCollateralToken, setCurrentStep]);
+  }, [showOnlySingleTokenAddress, whitelistedChainTokens, setSelectedCollateralToken, setCurrentStep]);
   const mapStepToComponent = useMemo(
     () => ({
       [BorrowSectionSteps.SELECT_TOKEN]: <CollateralTokenList />,

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -20,26 +20,24 @@ const RenderComponent: React.FC = () => {
   const { currentStep, setCurrentStep, bidId, setSelectedCollateralToken } = useGetBorrowSectionContext();
   const chainId = useChainId();
 
+  const tokenAddress = showOnlySingleTokenAddress?.startsWith('0x') ? `0x${showOnlySingleTokenAddress}` : undefined;
+  const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || '');
+
   useEffect(() => {
-    console.log("showOnlySingleTokenAddress", showOnlySingleTokenAddress)
-    if (showOnlySingleTokenAddress?.startsWith('0x')) {
-      const tokenAddress = `0x${showOnlySingleTokenAddress}`;
-      const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress);
-      
-      if (tokenMetadata && !isLoading) {
-        setSelectedCollateralToken({
-          address: `0x${tokenAddress}`,
-          name: tokenMetadata.name || '',
-          symbol: tokenMetadata.symbol || '',
-          logo: tokenMetadata.logo || '',
-          balance: '0',
-          decimals: tokenMetadata.decimals || 18,
-          chainId
-        });
-        setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
-      }
+    console.log("showOnlySingleTokenAddress", showOnlySingleTokenAddress);
+    if (tokenAddress && tokenMetadata && !isLoading) {
+      setSelectedCollateralToken({
+        address: tokenAddress as `0x${string}`,
+        name: tokenMetadata.name || '',
+        symbol: tokenMetadata.symbol || '',
+        logo: tokenMetadata.logo || '',
+        balance: '0',
+        decimals: tokenMetadata.decimals || 18,
+        chainId
+      });
+      setCurrentStep(BorrowSectionSteps.SELECT_OPPORTUNITY);
     }
-  }, [showOnlySingleTokenAddress, whitelistedChainTokens, setSelectedCollateralToken, setCurrentStep]);
+  }, [tokenAddress, tokenMetadata, isLoading, chainId, setSelectedCollateralToken, setCurrentStep]);
   const mapStepToComponent = useMemo(
     () => ({
       [BorrowSectionSteps.SELECT_TOKEN]: <CollateralTokenList />,

--- a/src/pages/BorrowSection/BorrowSectionContext.tsx
+++ b/src/pages/BorrowSection/BorrowSectionContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState } from "react";
 import { UserToken } from "../../hooks/useGetUserTokens";
 import { useGetCommitmentsForUserTokens } from "../../hooks/queries/useGetCommitmentsForUserTokens";
 import { CommitmentType } from "../../hooks/queries/useGetCommitmentsForCollateralToken";
+import { useGetGlobalPropsContext } from "../../contexts/GlobalPropsContext";
 
 export enum BorrowSectionSteps {
   SELECT_TOKEN,

--- a/src/pages/BorrowSection/BorrowSectionContext.tsx
+++ b/src/pages/BorrowSection/BorrowSectionContext.tsx
@@ -43,7 +43,9 @@ export const BorrowSectionContextProvider: React.FC<
 > = ({ children }) => {
   const { singleWhitelistedToken } = useGetGlobalPropsContext();
   const [currentStep, setCurrentStep] = useState<BorrowSectionSteps>(
-    singleWhitelistedToken ? BorrowSectionSteps.SELECT_OPPORTUNITY : BorrowSectionSteps.SELECT_TOKEN
+    singleWhitelistedToken
+      ? BorrowSectionSteps.SELECT_OPPORTUNITY
+      : BorrowSectionSteps.SELECT_TOKEN
   );
 
   const [selectedCollateralToken, setSelectedCollateralToken] =

--- a/src/pages/BorrowSection/BorrowSectionContext.tsx
+++ b/src/pages/BorrowSection/BorrowSectionContext.tsx
@@ -40,8 +40,9 @@ const BorrowSectionContext = createContext<BorrowSectionContextType>(
 export const BorrowSectionContextProvider: React.FC<
   BorrowSectionContextProps
 > = ({ children }) => {
+  const { showOnlySingleTokenAddress } = useGetGlobalPropsContext();
   const [currentStep, setCurrentStep] = useState<BorrowSectionSteps>(
-    BorrowSectionSteps.SELECT_TOKEN
+    showOnlySingleTokenAddress ? BorrowSectionSteps.SELECT_OPPORTUNITY : BorrowSectionSteps.SELECT_TOKEN
   );
 
   const [selectedCollateralToken, setSelectedCollateralToken] =

--- a/src/pages/BorrowSection/BorrowSectionContext.tsx
+++ b/src/pages/BorrowSection/BorrowSectionContext.tsx
@@ -41,9 +41,9 @@ const BorrowSectionContext = createContext<BorrowSectionContextType>(
 export const BorrowSectionContextProvider: React.FC<
   BorrowSectionContextProps
 > = ({ children }) => {
-  const { showOnlySingleTokenAddress } = useGetGlobalPropsContext();
+  const { singleWhitelistedToken } = useGetGlobalPropsContext();
   const [currentStep, setCurrentStep] = useState<BorrowSectionSteps>(
-    showOnlySingleTokenAddress ? BorrowSectionSteps.SELECT_OPPORTUNITY : BorrowSectionSteps.SELECT_TOKEN
+    singleWhitelistedToken ? BorrowSectionSteps.SELECT_OPPORTUNITY : BorrowSectionSteps.SELECT_TOKEN
   );
 
   const [selectedCollateralToken, setSelectedCollateralToken] =

--- a/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
+++ b/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
@@ -148,7 +148,6 @@ const OpportunitiesList: React.FC = () => {
       <div className="opportunities-list-header">
         {selectedCollateralToken && (
           <>
-            <div className="section-title">My token collateral</div>
             <TokenDropdown
               tokens={tokensWithCommitments}
               selectedToken={selectedCollateralToken}

--- a/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
+++ b/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
@@ -118,12 +118,10 @@ const OpportunityListItem: React.FC<OpportunityListItemProps> = ({
       <div className="opportunity-list-item-body">
         <OpportunityListDataItem
           label="Interest"
-          value={`${
-            (
-              (Number(opportunity.minAPY) / 100) *
-              (Number(opportunity.maxDuration) / 86400 / 365)
-            ).toFixed(2)
-          } %`}
+          value={`${(
+            (Number(opportunity.minAPY) / 100) *
+            (Number(opportunity.maxDuration) / 86400 / 365)
+          ).toFixed(2)} %`}
         />
         <OpportunityListDataItem
           label="Duration"
@@ -171,15 +169,18 @@ const OpportunitiesList: React.FC = () => {
                 minHeight: "200px",
               }}
             >
-              <div
-                className="section-title"
-                style={{ marginBottom: "1rem" }}
-              >
-                No liquidity found &nbsp; 👀 
+              <div className="section-title" style={{ marginBottom: "1rem" }}>
+                No liquidity found &nbsp; 👀
               </div>
               <Button
                 label={
-                  <span style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  <span
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
                     Deploy ${selectedCollateralToken?.symbol} pool
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -200,7 +201,6 @@ const OpportunitiesList: React.FC = () => {
                   </span>
                 }
                 variant="secondary"
-                
                 onClick={() =>
                   window.open(
                     "https://app.teller.org/lend",
@@ -212,7 +212,10 @@ const OpportunitiesList: React.FC = () => {
             </div>
           ) : (
             data.commitments.map((commitment) => (
-              <OpportunityListItem opportunity={commitment} key={commitment.id} />
+              <OpportunityListItem
+                opportunity={commitment}
+                key={commitment.id}
+              />
             ))
           )}
         </div>

--- a/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
+++ b/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
@@ -65,9 +65,8 @@ const OpportunityListItem: React.FC<OpportunityListItemProps> = ({
 
   // TODO: ADD SOCIAL FI CONDITIONAL
   useEffect(() => {
-    if (commitmentMax.maxCollateral > 0) {
+    commitmentMax.maxCollateral > 0 &&
       setCollateralAmount(commitmentMax.maxCollateral);
-    }
   }, [commitmentMax.maxCollateral]);
 
   const displayCollateralAmountData = {
@@ -114,7 +113,7 @@ const OpportunityListItem: React.FC<OpportunityListItemProps> = ({
           label={displayLoanAmountData.formattedAmount}
           logo={displayLoanAmountData.token}
         />
-        <img src={caret} alt="caret" />
+        <img src={caret} />
       </div>
       <div className="opportunity-list-item-body">
         <OpportunityListDataItem

--- a/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
+++ b/src/pages/BorrowSection/OpportunitiesList/OpportunitiesList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import TokenDropdown from "../../../components/TokenDropdown";
+import Button from "../../../components/Button";
 import {
   CommitmentType,
   useGetCommitmentsForCollateralToken,
@@ -64,8 +65,9 @@ const OpportunityListItem: React.FC<OpportunityListItemProps> = ({
 
   // TODO: ADD SOCIAL FI CONDITIONAL
   useEffect(() => {
-    commitmentMax.maxCollateral > 0 &&
+    if (commitmentMax.maxCollateral > 0) {
       setCollateralAmount(commitmentMax.maxCollateral);
+    }
   }, [commitmentMax.maxCollateral]);
 
   const displayCollateralAmountData = {
@@ -94,20 +96,6 @@ const OpportunityListItem: React.FC<OpportunityListItemProps> = ({
     token: SUPPORTED_TOKEN_LOGOS[opportunity.principalToken?.symbol as string],
   };
 
-  const formatedCollateralAmount = Number(
-    formatUnits(
-      commitmentMax.maxCollateral,
-      opportunity.collateralToken?.decimals ?? 0
-    )
-  ).toFixed(2);
-
-  const formatedLoanAmount = Number(
-    formatUnits(
-      commitmentMax.maxLoanAmount,
-      opportunity.principalToken?.decimals ?? 0
-    )
-  ).toFixed(2);
-
   const handleOnOpportunityClick = () => {
     setSelectedOpportunity(opportunity);
     setCurrentStep(BorrowSectionSteps.OPPORTUNITY_DETAILS);
@@ -126,13 +114,16 @@ const OpportunityListItem: React.FC<OpportunityListItemProps> = ({
           label={displayLoanAmountData.formattedAmount}
           logo={displayLoanAmountData.token}
         />
-        <img src={caret} />
+        <img src={caret} alt="caret" />
       </div>
       <div className="opportunity-list-item-body">
         <OpportunityListDataItem
           label="Interest"
           value={`${
-            ((Number(opportunity.minAPY) / 100) * ((Number(opportunity.maxDuration) / 86400) / 365)).toFixed(2)
+            (
+              (Number(opportunity.minAPY) / 100) *
+              (Number(opportunity.maxDuration) / 86400 / 365)
+            ).toFixed(2)
           } %`}
         />
         <OpportunityListDataItem
@@ -171,9 +162,61 @@ const OpportunitiesList: React.FC = () => {
           <div className="paragraph opportunities-sub-title">
             My opportunities
           </div>
-          {data.commitments.map((commitment) => (
-            <OpportunityListItem opportunity={commitment} key={commitment.id} />
-          ))}
+          {data.commitments.length === 0 ? (
+            <div
+              className="empty-opportunities"
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                minHeight: "200px",
+              }}
+            >
+              <div
+                className="section-title"
+                style={{ marginBottom: "1rem" }}
+              >
+                No liquidity found &nbsp; 👀 
+              </div>
+              <Button
+                label={
+                  <span style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+                    Deploy ${selectedCollateralToken?.symbol} pool
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      viewBox="0 0 24 24"
+                      style={{ marginLeft: "0.5rem" }}
+                    >
+                      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                      <polyline points="15 3 21 3 21 9" />
+                      <line x1="10" y1="14" x2="21" y2="3" />
+                    </svg>
+                  </span>
+                }
+                variant="secondary"
+                
+                onClick={() =>
+                  window.open(
+                    "https://app.teller.org/lend",
+                    "_blank",
+                    "noopener,noreferrer"
+                  )
+                }
+              />
+            </div>
+          ) : (
+            data.commitments.map((commitment) => (
+              <OpportunityListItem opportunity={commitment} key={commitment.id} />
+            ))
+          )}
         </div>
       )}
     </div>

--- a/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
+++ b/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
@@ -30,6 +30,7 @@ const OpportunityDetails = () => {
     useGetBorrowSectionContext();
   const { isWhitelistedToken } = useGetGlobalPropsContext();
   const whitelistedToken = isWhitelistedToken(selectedCollateralToken?.address);
+  const [staticMaxCollateral, setStaticMaxCollateral] = useState<bigint>();
 
   const isWhitelistedTokenAndUserHasNoBalance =
     whitelistedToken && Number(selectedCollateralToken?.balance) === 0;
@@ -66,6 +67,10 @@ const OpportunityDetails = () => {
       return;
     }
 
+    if (!staticMaxCollateral && maxCollateral) {
+      setStaticMaxCollateral(maxCollateral);
+    }
+
     setCollateralTokenValue((prev) => {
       if (prev.valueBI === maxCollateral) {
         return prev;
@@ -83,6 +88,7 @@ const OpportunityDetails = () => {
     isWhitelistedTokenAndUserHasNoBalance,
     maxCollateral,
     selectedCollateralToken?.decimals,
+    staticMaxCollateral,
   ]);
 
   const { isNewBorrower } = useIsNewBorrower();
@@ -149,7 +155,7 @@ const OpportunityDetails = () => {
         imageUrl={selectedCollateralToken?.logo || ""}
         sublabelUpper={`Max: ${numberWithCommasAndDecimals(
           formatUnits(
-            maxCollateral ?? 0n,
+            staticMaxCollateral ?? 0n,
             selectedCollateralToken?.decimals ?? 0
           )
         )} ${selectedCollateralToken?.symbol}`}

--- a/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
+++ b/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
@@ -4,6 +4,7 @@ import separatorWithCaret from "../../../assets/separator_with_caret.svg";
 import BackButton from "../../../components/BackButton";
 import DataField from "../../../components/DataField";
 import TokenInput from "../../../components/TokenInput";
+import Tooltip from "../../../components/Tooltip";
 import { TokenInputType } from "../../../components/TokenInput/TokenInput";
 import { SUPPORTED_TOKEN_LOGOS } from "../../../constants/tokens";
 import { useGetGlobalPropsContext } from "../../../contexts/GlobalPropsContext";
@@ -129,10 +130,24 @@ const OpportunityDetails = () => {
       />
       <TokenInput
         tokenValue={collateralTokenValue}
-        label="Deposit collateral"
+        label={
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            Deposit
+            <Tooltip
+              description={`Deposit $${selectedCollateralToken?.symbol} to borrow $${selectedOpportunity?.principalToken?.symbol} for ${convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days—extend anytime via rollover.`}
+              icon={
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="rollover-svg" style={{ position: 'relative', top: '1px' }}>
+                  <circle cx="12" cy="12" r="10" strokeWidth="2"/>
+                  <path d="M12 16v-4" strokeWidth="2"/>
+                  <circle cx="12" cy="8" r="1"/>
+                </svg>
+              }
+            />
+          </div>
+        }
         maxAmount={Number(selectedCollateralToken?.balance ?? 0)}
         imageUrl={selectedCollateralToken?.logo || ""}
-        sublabel={`Max collateral: ${numberWithCommasAndDecimals(
+        sublabelUpper={`Max: ${numberWithCommasAndDecimals(
           formatUnits(
             maxCollateral ?? 0n,
             selectedCollateralToken?.decimals ?? 0
@@ -140,16 +155,6 @@ const OpportunityDetails = () => {
         )} ${selectedCollateralToken?.symbol}`}
         onChange={setCollateralTokenValue}
       />
-      <div className="duration-info">
-        <DataField label="Duration">
-          {convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days
-        </DataField>
-        {extensionCount > 0 && (
-          <div className="section-sub-title">
-            Max extension: {maxExtensionInDays} days
-          </div>
-        )}
-      </div>
       <img src={separatorWithCaret} className="separator" />
       <TokenInput
         tokenValue={{
@@ -162,11 +167,34 @@ const OpportunityDetails = () => {
           ),
           valueBI: displayedPrincipal,
         }}
-        label="Borrow"
+        label={
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            Borrow
+            <Tooltip
+              description={`Borrow $${selectedOpportunity?.principalToken?.symbol} for ${convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days—extend anytime via rollover.`}
+              icon={
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="rollover-svg" style={{ position: 'relative', top: '1px' }}>
+                  <circle cx="12" cy="12" r="10" strokeWidth="2"/>
+                  <path d="M12 16v-4" strokeWidth="2"/>
+                  <circle cx="12" cy="8" r="1"/>
+                </svg>
+              }
+            />
+          </div>
+        }
         imageUrl={
           SUPPORTED_TOKEN_LOGOS[
             selectedOpportunity.principalToken?.symbol ?? ""
           ]
+        }
+        sublabelUpper={
+          <span>
+            Duration: {convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days • Rollover: {' '}
+            <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="12" height="12" viewBox="0 0 50 50" className="rollover-svg">
+              <g transform="translate(0, 9)">
+            <path d="M 25 2 C 12.317 2 2 12.317 2 25 C 2 37.683 12.317 48 25 48 C 37.683 48 48 37.683 48 25 C 48 20.44 46.660281 16.189328 44.363281 12.611328 L 42.994141 14.228516 C 44.889141 17.382516 46 21.06 46 25 C 46 36.579 36.579 46 25 46 C 13.421 46 4 36.579 4 25 C 4 13.421 13.421 4 25 4 C 30.443 4 35.393906 6.0997656 39.128906 9.5097656 L 40.4375 7.9648438 C 36.3525 4.2598437 30.935 2 25 2 z M 43.236328 7.7539062 L 23.914062 30.554688 L 15.78125 22.96875 L 14.417969 24.431641 L 24.083984 33.447266 L 44.763672 9.046875 L 43.236328 7.7539062 z"></path></g>
+            </svg>
+          </span>
         }
         readonly
       />

--- a/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
+++ b/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
@@ -142,7 +142,7 @@ const OpportunityDetails = () => {
             <Tooltip
               description={`Deposit $${selectedCollateralToken?.symbol} to borrow $${selectedOpportunity?.principalToken?.symbol} for ${convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days—extend anytime via rollover.`}
               icon={
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="rollover-svg" style={{ position: 'relative', top: '1px' }}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="tooltip-svg" style={{ position: 'relative', top: '1px' }}>
                   <circle cx="12" cy="12" r="10" strokeWidth="2"/>
                   <path d="M12 16v-4" strokeWidth="2"/>
                   <circle cx="12" cy="8" r="1"/>
@@ -179,7 +179,7 @@ const OpportunityDetails = () => {
             <Tooltip
               description={`Borrow $${selectedOpportunity?.principalToken?.symbol} for ${convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days—extend anytime via rollover.`}
               icon={
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="rollover-svg" style={{ position: 'relative', top: '1px' }}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="tooltip-svg" style={{ position: 'relative', top: '1px' }}>
                   <circle cx="12" cy="12" r="10" strokeWidth="2"/>
                   <path d="M12 16v-4" strokeWidth="2"/>
                   <circle cx="12" cy="8" r="1"/>
@@ -196,10 +196,28 @@ const OpportunityDetails = () => {
         sublabelUpper={
           <span>
             Duration: {convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days • Rollover: {' '}
-            <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="12" height="12" viewBox="0 0 50 50" className="rollover-svg">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              overflow="visible"
+              x="0px"
+              y="0px"
+              width="12"
+              height="12"
+              viewBox="0 0 50 50"
+              className="rollover-svg"
+            >
               <g transform="translate(0, 9)">
-            <path d="M 25 2 C 12.317 2 2 12.317 2 25 C 2 37.683 12.317 48 25 48 C 37.683 48 48 37.683 48 25 C 48 20.44 46.660281 16.189328 44.363281 12.611328 L 42.994141 14.228516 C 44.889141 17.382516 46 21.06 46 25 C 46 36.579 36.579 46 25 46 C 13.421 46 4 36.579 4 25 C 4 13.421 13.421 4 25 4 C 30.443 4 35.393906 6.0997656 39.128906 9.5097656 L 40.4375 7.9648438 C 36.3525 4.2598437 30.935 2 25 2 z M 43.236328 7.7539062 L 23.914062 30.554688 L 15.78125 22.96875 L 14.417969 24.431641 L 24.083984 33.447266 L 44.763672 9.046875 L 43.236328 7.7539062 z"></path></g>
+                <path
+                  className="outer"
+                  d="M 25 2 C 12.317 2 2 12.317 2 25 C 2 37.683 12.317 48 25 48 C 37.683 48 48 37.683 48 25 C 48 20.44 46.660281 16.189328 44.363281 12.611328 L 42.994141 14.228516 C 44.889141 17.382516 46 21.06 46 25 C 46 36.579 36.579 46 25 46 C 13.421 46 4 36.579 4 25 C 4 13.421 13.421 4 25 4 C 30.443 4 35.393906 6.0997656 39.128906 9.5097656 L 40.4375 7.9648438 C 36.3525 4.2598437 30.935 2 25 2 z"
+                ></path>
+                <path
+                  className="check"
+                  d="M 43.236328 7.7539062 L 23.914062 30.554688 L 15.78125 22.96875 L 14.417969 24.431641 L 24.083984 33.447266 L 44.763672 9.046875 L 43.236328 7.7539062 z"
+                ></path>
+              </g>
             </svg>
+
           </span>
         }
         readonly

--- a/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
+++ b/src/pages/BorrowSection/OpportunityDetails/OpportunityDetails.tsx
@@ -137,15 +137,28 @@ const OpportunityDetails = () => {
       <TokenInput
         tokenValue={collateralTokenValue}
         label={
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
             Deposit
             <Tooltip
-              description={`Deposit $${selectedCollateralToken?.symbol} to borrow $${selectedOpportunity?.principalToken?.symbol} for ${convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days—extend anytime via rollover.`}
+              description={`Deposit $${
+                selectedCollateralToken?.symbol
+              } to borrow $${
+                selectedOpportunity?.principalToken?.symbol
+              } for ${convertSecondsToDays(
+                Number(selectedOpportunity?.maxDuration)
+              )} days—extend anytime via rollover.`}
               icon={
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="tooltip-svg" style={{ position: 'relative', top: '1px' }}>
-                  <circle cx="12" cy="12" r="10" strokeWidth="2"/>
-                  <path d="M12 16v-4" strokeWidth="2"/>
-                  <circle cx="12" cy="8" r="1"/>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  className="tooltip-svg"
+                  style={{ position: "relative", top: "1px" }}
+                >
+                  <circle cx="12" cy="12" r="10" strokeWidth="2" />
+                  <path d="M12 16v-4" strokeWidth="2" />
+                  <circle cx="12" cy="8" r="1" />
                 </svg>
               }
             />
@@ -174,15 +187,26 @@ const OpportunityDetails = () => {
           valueBI: displayedPrincipal,
         }}
         label={
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
             Borrow
             <Tooltip
-              description={`Borrow $${selectedOpportunity?.principalToken?.symbol} for ${convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days—extend anytime via rollover.`}
+              description={`Borrow $${
+                selectedOpportunity?.principalToken?.symbol
+              } for ${convertSecondsToDays(
+                Number(selectedOpportunity?.maxDuration)
+              )} days—extend anytime via rollover.`}
               icon={
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="tooltip-svg" style={{ position: 'relative', top: '1px' }}>
-                  <circle cx="12" cy="12" r="10" strokeWidth="2"/>
-                  <path d="M12 16v-4" strokeWidth="2"/>
-                  <circle cx="12" cy="8" r="1"/>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  className="tooltip-svg"
+                  style={{ position: "relative", top: "1px" }}
+                >
+                  <circle cx="12" cy="12" r="10" strokeWidth="2" />
+                  <path d="M12 16v-4" strokeWidth="2" />
+                  <circle cx="12" cy="8" r="1" />
                 </svg>
               }
             />
@@ -195,7 +219,9 @@ const OpportunityDetails = () => {
         }
         sublabelUpper={
           <span>
-            Duration: {convertSecondsToDays(Number(selectedOpportunity?.maxDuration))} days • Rollover: {' '}
+            Duration:{" "}
+            {convertSecondsToDays(Number(selectedOpportunity?.maxDuration))}{" "}
+            days • Rollover:{" "}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               overflow="visible"
@@ -217,7 +243,6 @@ const OpportunityDetails = () => {
                 ></path>
               </g>
             </svg>
-
           </span>
         }
         readonly

--- a/src/pages/RepaySection/RepaySection.tsx
+++ b/src/pages/RepaySection/RepaySection.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-
+import { useMemo, useEffect } from "react";
+import { useChainId } from "wagmi";
 import RolloverLoan from "../RolloverLoan";
 
 import Loans from "./Loans";
@@ -16,6 +16,7 @@ import AddToCalendar from "../../components/AddToCalendar";
 
 const RenderComponent: React.FC = () => {
   const { currentStep, bidId, setCurrentStep } = useGetRepaySectionContext();
+  const chainId = useChainId();
   const mapStepToComponent = useMemo(
     () => ({
       [RepaySectionSteps.LOANS]: <Loans />,
@@ -32,6 +33,18 @@ const RenderComponent: React.FC = () => {
     }),
     []
   );
+
+  useEffect(() => {
+    if (currentStep === RepaySectionSteps.LOANS) {
+      setCurrentStep(null as any);
+      setTimeout(() => {
+        setCurrentStep(RepaySectionSteps.LOANS);
+      }, 0);
+    } else {
+      setCurrentStep(RepaySectionSteps.LOANS);
+    }
+  }, [chainId]);
+
 
   return <div className="repay-section">{mapStepToComponent[currentStep]}</div>;
 };

--- a/src/pages/RepaySection/RepaySection.tsx
+++ b/src/pages/RepaySection/RepaySection.tsx
@@ -35,24 +35,17 @@ const RenderComponent: React.FC = () => {
   );
 
   useEffect(() => {
-    if (currentStep === RepaySectionSteps.LOANS) {
-      setCurrentStep(null as any);
-      setTimeout(() => {
-        setCurrentStep(RepaySectionSteps.LOANS);
-      }, 0);
-    } else {
-      setCurrentStep(RepaySectionSteps.LOANS);
-    }
+    setCurrentStep(RepaySectionSteps.LOANS);
   }, [chainId]);
-
 
   return <div className="repay-section">{mapStepToComponent[currentStep]}</div>;
 };
 
 const RepaySection = () => {
+  const chainId = useChainId();
   return (
     <RepaySectionContextProvider>
-      <RenderComponent />
+      <RenderComponent key={chainId} />
     </RepaySectionContextProvider>
   );
 };


### PR DESCRIPTION
- Show only single token option
- Improved borrow layout
- Chain switch on repay updates page
- Search on Opportunities List dropdown
- Click Borrow tab any time, goes back to Collateral List