### PR TITLE
ENG-397 Add new borrowToken prop to automatically show the borrow page

### DIFF
--- a/src/components/ModalContent/ModalContent.tsx
+++ b/src/components/ModalContent/ModalContent.tsx
@@ -55,7 +55,7 @@ const ModalContent: React.FC<ModalContentProps> = ({
   };
 
   const mapOptionToComponent = {
-    [WIDGET_ACTION_ENUM.BORROW]: <BorrowSection key={key} />,
+    [WIDGET_ACTION_ENUM.BORROW]: <BorrowSection key={key} internalKey={key} />,
     [WIDGET_ACTION_ENUM.REPAY]: <RepaySection key={key} />,
     [WIDGET_ACTION_ENUM.POOL]: <PoolSection />,
     [WIDGET_ACTION_ENUM.STRATEGIES]: <BorrowSection key={key} />,

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -48,6 +48,7 @@ interface BaseWidgetProps {
   isTradeMode?: boolean;
   strategy?: STRATEGY_ACTION_ENUM.LONG | STRATEGY_ACTION_ENUM.SHORT;
   strategyToken?: string;
+  borrowToken?: string;
 }
 
 interface WhiteListedTokensRequiredProps extends BaseWidgetProps {
@@ -91,6 +92,7 @@ const Widget: React.FC<WidgetProps> = ({
   isTradeMode,
   strategy,
   strategyToken,
+  borrowToken,
 }) => {
   const [showModal, setShowModal] = useState(showModalByDefault || false);
 
@@ -121,6 +123,7 @@ const Widget: React.FC<WidgetProps> = ({
           isTradeMode={isTradeMode}
           initialStrategyAction={strategy}
           strategyToken={strategyToken}
+          borrowToken={borrowToken}
         >
           <TransactionButtonProvider>
             <div className="teller-widget">

--- a/src/components/Widget/widget.stories.tsx
+++ b/src/components/Widget/widget.stories.tsx
@@ -103,6 +103,10 @@ const meta = {
       description: "Token address to automatically load in strategy section",
       control: { type: "text" },
     },
+    borrowToken: {
+      description: "Token address to automatically load in borrow section",
+      control: { type: "text" },
+    },
   },
   args: {
     hideAutoConnectModal: true,

--- a/src/contexts/GlobalPropsContext.tsx
+++ b/src/contexts/GlobalPropsContext.tsx
@@ -144,6 +144,10 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
     }
   }, [initialStrategyAction]);
 
+  useEffect(() => {
+    setIsInitialTokenProcessed(false);
+  }, [strategyToken, borrowToken]);
+
   const isWhitelistedToken = useCallback(
     (token?: Address | undefined) => {
       const result = token ? whitelistedChainTokens.includes(token) : false;

--- a/src/contexts/GlobalPropsContext.tsx
+++ b/src/contexts/GlobalPropsContext.tsx
@@ -49,8 +49,6 @@ export type GlobalPropsContextType = {
   isTradeMode?: boolean;
   strategyToken?: string;
   borrowToken?: string;
-  isInitialTokenProcessed?: boolean;
-  setIsInitialTokenProcessed: (isInitialTokenProcessed: boolean) => void;
 };
 
 interface GlobalPropsContextProps {
@@ -136,17 +134,11 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
     initialStrategyAction || STRATEGY_ACTION_ENUM.LONG
   );
 
-  const [isInitialTokenProcessed, setIsInitialTokenProcessed] = useState(false);
-
   useEffect(() => {
     if (initialStrategyAction) {
       setStrategyAction(initialStrategyAction);
     }
   }, [initialStrategyAction]);
-
-  useEffect(() => {
-    setIsInitialTokenProcessed(false);
-  }, [strategyToken, borrowToken]);
 
   const isWhitelistedToken = useCallback(
     (token?: Address | undefined) => {
@@ -180,8 +172,6 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
       isTradeMode,
       strategyToken,
       borrowToken,
-      isInitialTokenProcessed,
-      setIsInitialTokenProcessed,
     };
   }, [
     userTokens,
@@ -204,8 +194,6 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
     isTradeMode,
     strategyToken,
     borrowToken,
-    isInitialTokenProcessed,
-    setIsInitialTokenProcessed,
   ]);
 
   return (

--- a/src/contexts/GlobalPropsContext.tsx
+++ b/src/contexts/GlobalPropsContext.tsx
@@ -48,6 +48,9 @@ export type GlobalPropsContextType = {
   whitelistedTokens?: WhitelistedTokens;
   isTradeMode?: boolean;
   strategyToken?: string;
+  borrowToken?: string;
+  isInitialTokenProcessed?: boolean;
+  setIsInitialTokenProcessed: (isInitialTokenProcessed: boolean) => void;
 };
 
 interface GlobalPropsContextProps {
@@ -67,6 +70,7 @@ interface GlobalPropsContextProps {
   isTradeMode?: boolean;
   initialStrategyAction?: STRATEGY_ACTION_ENUM;
   strategyToken?: string;
+  borrowToken?: string;
 }
 
 const GlobalPropsContext = createContext({} as GlobalPropsContextType);
@@ -88,6 +92,7 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
   isTradeMode = false,
   initialStrategyAction,
   strategyToken,
+  borrowToken,
 }) => {
   const { address } = useAccount();
   const chainId = useChainId();
@@ -131,6 +136,8 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
     initialStrategyAction || STRATEGY_ACTION_ENUM.LONG
   );
 
+  const [isInitialTokenProcessed, setIsInitialTokenProcessed] = useState(false);
+
   useEffect(() => {
     if (initialStrategyAction) {
       setStrategyAction(initialStrategyAction);
@@ -168,6 +175,9 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
       whitelistedTokens,
       isTradeMode,
       strategyToken,
+      borrowToken,
+      isInitialTokenProcessed,
+      setIsInitialTokenProcessed,
     };
   }, [
     userTokens,
@@ -189,6 +199,9 @@ export const GlobalContextProvider: React.FC<GlobalPropsContextProps> = ({
     whitelistedTokens,
     isTradeMode,
     strategyToken,
+    borrowToken,
+    isInitialTokenProcessed,
+    setIsInitialTokenProcessed,
   ]);
 
   return (

--- a/src/hooks/queries/useGetCommitmentsForCollateralTokensFromLiquidityPools.ts
+++ b/src/hooks/queries/useGetCommitmentsForCollateralTokensFromLiquidityPools.ts
@@ -19,7 +19,7 @@ export const useGetCommitmentsForCollateralTokensFromLiquidityPools = (
     () => gql`
       query groupDashboardCommitmentsFor${collateralTokenAddress} {
         group_pool_metric(
-          where: { collateral_token_address: {_eq: "${collateralTokenAddress}" } }
+          where: { collateral_token_address: {_eq: "${collateralTokenAddress.toLowerCase()}" } }
         ) {
           id
           market_id

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -26,7 +26,11 @@ import { useGetTokenList } from "../../hooks/queries/useGetTokenList";
 import { CommitmentType } from "../../hooks/queries/useGetCommitmentsForCollateralToken";
 import { UserToken } from "../../hooks/useGetUserTokens";
 
-const RenderComponent: React.FC = () => {
+interface Props {
+  internalKey?: number;
+}
+
+const RenderComponent: React.FC<Props> = ({ internalKey = 0 }) => {
   const {
     singleWhitelistedToken,
     userTokens,
@@ -147,7 +151,7 @@ const RenderComponent: React.FC = () => {
       return;
     }
 
-    if (borrowToken && !isStrategiesSection) {
+    if (borrowToken && !isStrategiesSection && internalKey === 0) {
       processTokenInitialization(tokenData);
       return;
     }
@@ -176,6 +180,7 @@ const RenderComponent: React.FC = () => {
     resetSelections,
     shouldResetForChainMismatch,
     processTokenInitialization,
+    internalKey,
   ]);
 
   const mapStepToComponent = useMemo(
@@ -207,10 +212,10 @@ const RenderComponent: React.FC = () => {
   );
 };
 
-const BorrowSection: React.FC = () => {
+const BorrowSection: React.FC<Props> = ({ internalKey }) => {
   return (
     <BorrowSectionContextProvider>
-      <RenderComponent />
+      <RenderComponent internalKey={internalKey || 0} />
     </BorrowSectionContextProvider>
   );
 };

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -35,8 +35,6 @@ const RenderComponent: React.FC = () => {
     isTradeMode,
     isStrategiesSection,
     borrowToken,
-    isInitialTokenProcessed,
-    setIsInitialTokenProcessed,
   } = useGetGlobalPropsContext();
   const {
     currentStep,
@@ -53,12 +51,15 @@ const RenderComponent: React.FC = () => {
   const { switchChain } = useSwitchChain();
   const { data: tokenList } = useGetTokenList();
 
+  const [isInitialTokenProcessed, setIsInitialTokenProcessed] = useState(false);
+
   const tokenAddress =
     singleWhitelistedToken?.toLowerCase() ||
     (isStrategiesSection
       ? strategyToken?.toLowerCase()
       : borrowToken?.toLowerCase()) ||
     "";
+
   const { tokenMetadata, isLoading } = useGetTokenMetadata(tokenAddress || "");
 
   const resetSelections = useCallback(() => {
@@ -74,6 +75,10 @@ const RenderComponent: React.FC = () => {
     setSelectedOpportunity,
     setCurrentStep,
   ]);
+
+  useEffect(() => {
+    setIsInitialTokenProcessed(false);
+  }, [strategyToken, borrowToken]);
 
   const shouldResetForChainMismatch = useCallback(
     (enrichedTokenChainId: number, enrichedTokenAddress: string) =>

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -129,16 +129,16 @@ const RenderComponent: React.FC = () => {
       decimals: enrichedToken.decimals || 18,
       chainId: !address ? enrichedToken.chainId || chainId : undefined,
     };
+
     setIsInitialTokenProcessed(true);
+    if (isInitialTokenProcessed) {
+      return;
+    }
 
     if (
       shouldResetForChainMismatch(enrichedToken.chainId, enrichedToken.address)
     ) {
       resetSelections();
-      return;
-    }
-
-    if (isInitialTokenProcessed) {
       return;
     }
 

--- a/src/pages/BorrowSection/BorrowSection.tsx
+++ b/src/pages/BorrowSection/BorrowSection.tsx
@@ -129,37 +129,25 @@ const RenderComponent: React.FC = () => {
       decimals: enrichedToken.decimals || 18,
       chainId: !address ? enrichedToken.chainId || chainId : undefined,
     };
+    setIsInitialTokenProcessed(true);
 
-    if (borrowToken && !isInitialTokenProcessed && !isStrategiesSection) {
-      setIsInitialTokenProcessed(true);
+    if (
+      shouldResetForChainMismatch(enrichedToken.chainId, enrichedToken.address)
+    ) {
+      resetSelections();
+      return;
+    }
 
-      if (
-        shouldResetForChainMismatch(
-          enrichedToken.chainId,
-          enrichedToken.address
-        )
-      ) {
-        resetSelections();
-        return;
-      }
+    if (isInitialTokenProcessed) {
+      return;
+    }
 
+    if (borrowToken && !isStrategiesSection) {
       processTokenInitialization(tokenData);
       return;
     }
 
-    if (strategyToken && !isInitialTokenProcessed && isStrategiesSection) {
-      setIsInitialTokenProcessed(true);
-
-      if (
-        shouldResetForChainMismatch(
-          enrichedToken.chainId,
-          enrichedToken.address
-        )
-      ) {
-        resetSelections();
-        return;
-      }
-
+    if (strategyToken && isStrategiesSection) {
       const isLongStrategy =
         !!strategyToken && strategyAction === STRATEGY_ACTION_ENUM.LONG;
       processTokenInitialization(tokenData, isLongStrategy);


### PR DESCRIPTION
Testing criteria: 
That the widget automatically goes to the opportunities list with the token in the prop
If you close and re open the widget the token stays visible
When you click on borrow the list resets 